### PR TITLE
TORE paper added

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@
     - [Control](#control)
     - [Space Applications](#space)
     - [Tactile Sensing Applications](#tactile_sensing)
+    - [Pose Estimation](#pose_estimation)
+        - [3D Human Pose Estimation](#3d_human_pose_estimation)
+        - [3D Hand Pose Estimation](#3d_hand_pose_estimation)
 
 - [Datasets and Simulators](#datasets)
 - [Software](#software)
@@ -1847,20 +1850,15 @@ Robotics: Science and Systems (RSS), 2020. [PDF](http://www.roboticsproceedings.
 *[A Miniaturised Neuromorphic Tactile Sensor Integrated with an Anthropomorphic Robot Hand](https://ras.papercept.net/proceedings/IROS20/1490.pdf)*,  
 IEEE/RSJ Int. Conf. Intelligent Robots and Systems (IROS), 2020.
 
+
 <a name="pose_estimation"></a>
 ## Pose Estimation
 
-<a name="3d_hand_pose_estimation"></a>
+<a name="3d_human_pose_estimation"></a>
 ### 3D Humna Pose Estimation
 - [Calabrese et al., CVPRW 2019](#Calabrese19cvprw). DHP19: Dynamic Vision Sensor 3D Human Pose Dataset.
+- [Xu et al., CVPR 2020](#Xu20cvpr). EventCap: Monocular 3D Capture of High-Speed Human Motions using an Event Camera.
 - [Baldwin et al., arXiv 2021](#Baldwin21arxiv). Time-Ordered Recent Event (TORE) Volumes for Event Cameras.
-- [Baldwin et al., arXiv 2021](#Baldwin21arxiv). Time-Ordered Recent Event (TORE) Volumes for Event Cameras.
-
-
-
-
-
-
 
 
 <a name="3d_hand_pose_estimation"></a>

--- a/README.md
+++ b/README.md
@@ -1696,6 +1696,11 @@ IEEE Trans. Multimedia (TMM), 2020.
 - <a name="Guo20arxiv"></a>Guo, S., Kang, Z., Wang, L., Zhang, L., Chen, X., Li, S., Xu, W.,  
 *[A Noise Filter for Dynamic Vision Sensors based on Global Space and Time Information](https://arxiv.org/pdf/2004.04079)*,  
 arXiv, 2020.
+- <a name="Baldwin21arxiv"></a>Baldwin R.W., Ruixu L., Almatrafi M., Asari V., Hirakawa K.,  
+*[Time-Ordered Recent Event (TORE) Volumes for Event Cameras](https://arxiv.org/abs/2103.06108)*,  
+arXiv, 2021. [PDF](https://arxiv.org/abs/2103.06108), [Code](https://github.com/bald6354/tore_volumes).
+- [Baldwin R.W., Ruixu L., Almatrafi M., Asari V., Hirakawa K.](#Baldwin21arxiv),  
+*Time-Ordered Recent Event (TORE) Volumes for Event Cameras.*
 
 
 <a name="compression"></a>

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@
     - [Control](#control)
     - [Space Applications](#space)
     - [Tactile Sensing Applications](#tactile_sensing)
-    - [Pose Estimation](#pose_estimation)
-        - [3D Human Pose Estimation](#3d_human_pose_estimation)
-        - [3D Hand Pose Estimation](#3d_hand_pose_estimation)
+    - [Object Pose Estimation](#object_pose_estimation)
+        - [Human Pose Estimation](#human_pose_estimation)
+        - [Hand Pose Estimation](#hand_pose_estimation)
 
 - [Datasets and Simulators](#datasets)
 - [Software](#software)
@@ -1851,18 +1851,18 @@ Robotics: Science and Systems (RSS), 2020. [PDF](http://www.roboticsproceedings.
 IEEE/RSJ Int. Conf. Intelligent Robots and Systems (IROS), 2020.
 
 
-<a name="pose_estimation"></a>
-## Pose Estimation
+<a name="object_pose_estimation"></a>
+## Object Pose Estimation
 
-<a name="3d_human_pose_estimation"></a>
-### 3D Humna Pose Estimation
+<a name="human_pose_estimation"></a>
+### Human Pose Estimation
 - [Calabrese et al., CVPRW 2019](#Calabrese19cvprw). DHP19: Dynamic Vision Sensor 3D Human Pose Dataset.
 - [Xu et al., CVPR 2020](#Xu20cvpr). EventCap: Monocular 3D Capture of High-Speed Human Motions using an Event Camera.
 - [Baldwin et al., arXiv 2021](#Baldwin21arxiv). Time-Ordered Recent Event (TORE) Volumes for Event Cameras.
 
 
-<a name="3d_hand_pose_estimation"></a>
-### 3D Hand Pose Estimation
+<a name="hand_pose_estimation"></a>
+### Hand Pose Estimation
 - <a name="Naeini20sensors"></a>Rudnev, V., Golyanik, V., Wang, J., Seidel, H.-P., Mueller, F., Elgharib, M., Theobalt, C.,  
 *[EventHands: Real-Time Neural 3D Hand Reconstruction from an Event Stream](https://arxiv.org/pdf/2012.06475)*,  
 arXiv, 2020. [Project page](https://gvv.mpi-inf.mpg.de/projects/EventHands/)

--- a/README.md
+++ b/README.md
@@ -1590,7 +1590,7 @@ IAPR IEEE Int. Conf. Pattern Recognition (ICPR), Milan, 2021.
 IEEE Trans. Pattern Anal. Machine Intell. (TPAMI), 2021.
 - <a name="Baldwin21arxiv"></a>Baldwin, R., Ruixu, L., Almatrafi, M., Asari, V., Hirakawa, K.,  
 *[Time-Ordered Recent Event (TORE) Volumes for Event Cameras](https://arxiv.org/abs/2103.06108)*,  
-arXiv, 2021. [Code](https://github.com/bald6354/tore_volumes).
+arXiv:2103.06108, 2021. [Code](https://github.com/bald6354/tore_volumes).
 
 
 <a name="learning-regression"></a>

--- a/README.md
+++ b/README.md
@@ -706,6 +706,8 @@ arXiv, 2020.
 - <a name="GantierCadena21tip"></a>Gantier Cadena, P. R., Qian, Y., Wang, C., Yang, M.,  
 *[SPADE-E2VID: Spatially-Adaptive Denormalization for Event-Based Video Reconstruction](https://doi.org/10.1109/TIP.2021.3052070)*,  
 IEEE Trans. Image Processing, 30:2488-2500, 2021. [Project page](https://github.com/RodrigoGantier/SPADE_E2VID)
+- [Baldwin R.W., Ruixu L., Almatrafi M., Asari V., Hirakawa K.](#Baldwin21arxiv),  
+*Time-Ordered Recent Event (TORE) Volumes for Event Cameras.*
 
 
 <a name="video-synthesis"></a>
@@ -1388,6 +1390,8 @@ IEEE Int. Conf. Image Processing (ICIP), 2020.
 - <a name="Deng20amae"></a>Y. Deng, Y. Li and H. Chen.,  
 *[AMAE: Adaptive Motion-Agnostic Encoder for Event-Based Object Classification](http://ras.papercept.net/images/temp/IROS/files/2483.pdf)*,  
 IEEE Robotics and Automation Letters (RA-L), 5(3):4596-4603, July 2020.
+- [Baldwin R.W., Ruixu L., Almatrafi M., Asari V., Hirakawa K.](#Baldwin21arxiv),  
+*Time-Ordered Recent Event (TORE) Volumes for Event Cameras.*
 
 
 <a name="gesture-recognition"></a>
@@ -1583,6 +1587,8 @@ IAPR IEEE Int. Conf. Pattern Recognition (ICPR), Milan, 2021.
 - <a name="Wang21tpami"></a>Wang. Y., Zhang, X., Shen, Y., Du, B., Zhao, G., Lizhen, L. C. C., Wen, H.,  
 *[Event-Stream Representation for Human Gaits Identification Using Deep Neural Networks](https://doi.org/10.1109/TPAMI.2021.3054886)*,  
 IEEE Trans. Pattern Anal. Machine Intell. (TPAMI), 2021.
+- [Baldwin R.W., Ruixu L., Almatrafi M., Asari V., Hirakawa K.](#Baldwin21arxiv),  
+*Time-Ordered Recent Event (TORE) Volumes for Event Cameras.*
 
 
 <a name="learning-regression"></a>
@@ -1699,8 +1705,6 @@ arXiv, 2020.
 - <a name="Baldwin21arxiv"></a>Baldwin R.W., Ruixu L., Almatrafi M., Asari V., Hirakawa K.,  
 *[Time-Ordered Recent Event (TORE) Volumes for Event Cameras](https://arxiv.org/abs/2103.06108)*,  
 arXiv, 2021. [PDF](https://arxiv.org/abs/2103.06108), [Code](https://github.com/bald6354/tore_volumes).
-- [Baldwin R.W., Ruixu L., Almatrafi M., Asari V., Hirakawa K.](#Baldwin21arxiv),  
-*Time-Ordered Recent Event (TORE) Volumes for Event Cameras.*
 
 
 <a name="compression"></a>

--- a/README.md
+++ b/README.md
@@ -706,7 +706,7 @@ arXiv, 2020.
 - <a name="GantierCadena21tip"></a>Gantier Cadena, P. R., Qian, Y., Wang, C., Yang, M.,  
 *[SPADE-E2VID: Spatially-Adaptive Denormalization for Event-Based Video Reconstruction](https://doi.org/10.1109/TIP.2021.3052070)*,  
 IEEE Trans. Image Processing, 30:2488-2500, 2021. [Project page](https://github.com/RodrigoGantier/SPADE_E2VID)
-- [Baldwin et al., Arxiv 2021](#Baldwin21arxiv). Time-Ordered Recent Event (TORE) Volumes for Event Cameras.
+- [Baldwin et al., arXiv 2021](#Baldwin21arxiv). Time-Ordered Recent Event (TORE) Volumes for Event Cameras.
 
 
 <a name="video-synthesis"></a>
@@ -1389,7 +1389,7 @@ IEEE Int. Conf. Image Processing (ICIP), 2020.
 - <a name="Deng20amae"></a>Y. Deng, Y. Li and H. Chen.,  
 *[AMAE: Adaptive Motion-Agnostic Encoder for Event-Based Object Classification](http://ras.papercept.net/images/temp/IROS/files/2483.pdf)*,  
 IEEE Robotics and Automation Letters (RA-L), 5(3):4596-4603, July 2020.
-- [Baldwin et al., Arxiv 2021](#Baldwin21arxiv). Time-Ordered Recent Event (TORE) Volumes for Event Cameras.
+- [Baldwin et al., arXiv 2021](#Baldwin21arxiv). Time-Ordered Recent Event (TORE) Volumes for Event Cameras.
 
 
 <a name="gesture-recognition"></a>
@@ -1701,7 +1701,7 @@ IEEE Trans. Multimedia (TMM), 2020.
 - <a name="Guo20arxiv"></a>Guo, S., Kang, Z., Wang, L., Zhang, L., Chen, X., Li, S., Xu, W.,  
 *[A Noise Filter for Dynamic Vision Sensors based on Global Space and Time Information](https://arxiv.org/pdf/2004.04079)*,  
 arXiv, 2020.
-- [Baldwin et al., Arxiv 2021](#Baldwin21arxiv). Time-Ordered Recent Event (TORE) Volumes for Event Cameras.
+- [Baldwin et al., arXiv 2021](#Baldwin21arxiv). Time-Ordered Recent Event (TORE) Volumes for Event Cameras.
 
 <a name="compression"></a>
 ### Compression
@@ -1847,8 +1847,24 @@ Robotics: Science and Systems (RSS), 2020. [PDF](http://www.roboticsproceedings.
 *[A Miniaturised Neuromorphic Tactile Sensor Integrated with an Anthropomorphic Robot Hand](https://ras.papercept.net/proceedings/IROS20/1490.pdf)*,  
 IEEE/RSJ Int. Conf. Intelligent Robots and Systems (IROS), 2020.
 
+<a name="pose_estimation"></a>
+## Pose Estimation
 
-## 3D hand pose estimation
+<a name="3d_hand_pose_estimation"></a>
+### 3D Humna Pose Estimation
+- [Calabrese et al., CVPRW 2019](#Calabrese19cvprw). DHP19: Dynamic Vision Sensor 3D Human Pose Dataset.
+- [Baldwin et al., arXiv 2021](#Baldwin21arxiv). Time-Ordered Recent Event (TORE) Volumes for Event Cameras.
+- [Baldwin et al., arXiv 2021](#Baldwin21arxiv). Time-Ordered Recent Event (TORE) Volumes for Event Cameras.
+
+
+
+
+
+
+
+
+<a name="3d_hand_pose_estimation"></a>
+### 3D Hand Pose Estimation
 - <a name="Naeini20sensors"></a>Rudnev, V., Golyanik, V., Wang, J., Seidel, H.-P., Mueller, F., Elgharib, M., Theobalt, C.,  
 *[EventHands: Real-Time Neural 3D Hand Reconstruction from an Event Stream](https://arxiv.org/pdf/2012.06475)*,  
 arXiv, 2020. [Project page](https://gvv.mpi-inf.mpg.de/projects/EventHands/)

--- a/README.md
+++ b/README.md
@@ -706,8 +706,7 @@ arXiv, 2020.
 - <a name="GantierCadena21tip"></a>Gantier Cadena, P. R., Qian, Y., Wang, C., Yang, M.,  
 *[SPADE-E2VID: Spatially-Adaptive Denormalization for Event-Based Video Reconstruction](https://doi.org/10.1109/TIP.2021.3052070)*,  
 IEEE Trans. Image Processing, 30:2488-2500, 2021. [Project page](https://github.com/RodrigoGantier/SPADE_E2VID)
-- [Baldwin R.W., Ruixu L., Almatrafi M., Asari V., Hirakawa K.](#Baldwin21arxiv),  
-*Time-Ordered Recent Event (TORE) Volumes for Event Cameras.*
+- [Baldwin et al., Arxiv 2021](#Baldwin21arxiv). Time-Ordered Recent Event (TORE) Volumes for Event Cameras.
 
 
 <a name="video-synthesis"></a>
@@ -1390,8 +1389,7 @@ IEEE Int. Conf. Image Processing (ICIP), 2020.
 - <a name="Deng20amae"></a>Y. Deng, Y. Li and H. Chen.,  
 *[AMAE: Adaptive Motion-Agnostic Encoder for Event-Based Object Classification](http://ras.papercept.net/images/temp/IROS/files/2483.pdf)*,  
 IEEE Robotics and Automation Letters (RA-L), 5(3):4596-4603, July 2020.
-- [Baldwin R.W., Ruixu L., Almatrafi M., Asari V., Hirakawa K.](#Baldwin21arxiv),  
-*Time-Ordered Recent Event (TORE) Volumes for Event Cameras.*
+- [Baldwin et al., Arxiv 2021](#Baldwin21arxiv). Time-Ordered Recent Event (TORE) Volumes for Event Cameras.
 
 
 <a name="gesture-recognition"></a>
@@ -1587,8 +1585,9 @@ IAPR IEEE Int. Conf. Pattern Recognition (ICPR), Milan, 2021.
 - <a name="Wang21tpami"></a>Wang. Y., Zhang, X., Shen, Y., Du, B., Zhao, G., Lizhen, L. C. C., Wen, H.,  
 *[Event-Stream Representation for Human Gaits Identification Using Deep Neural Networks](https://doi.org/10.1109/TPAMI.2021.3054886)*,  
 IEEE Trans. Pattern Anal. Machine Intell. (TPAMI), 2021.
-- [Baldwin R.W., Ruixu L., Almatrafi M., Asari V., Hirakawa K.](#Baldwin21arxiv),  
-*Time-Ordered Recent Event (TORE) Volumes for Event Cameras.*
+- <a name="Baldwin21arxiv"></a>Baldwin, R., Ruixu, L., Almatrafi, M., Asari, V., Hirakawa, K.,  
+*[Time-Ordered Recent Event (TORE) Volumes for Event Cameras](https://arxiv.org/abs/2103.06108)*,  
+arXiv, 2021. [Code](https://github.com/bald6354/tore_volumes).
 
 
 <a name="learning-regression"></a>
@@ -1702,10 +1701,7 @@ IEEE Trans. Multimedia (TMM), 2020.
 - <a name="Guo20arxiv"></a>Guo, S., Kang, Z., Wang, L., Zhang, L., Chen, X., Li, S., Xu, W.,  
 *[A Noise Filter for Dynamic Vision Sensors based on Global Space and Time Information](https://arxiv.org/pdf/2004.04079)*,  
 arXiv, 2020.
-- <a name="Baldwin21arxiv"></a>Baldwin R.W., Ruixu L., Almatrafi M., Asari V., Hirakawa K.,  
-*[Time-Ordered Recent Event (TORE) Volumes for Event Cameras](https://arxiv.org/abs/2103.06108)*,  
-arXiv, 2021. [PDF](https://arxiv.org/abs/2103.06108), [Code](https://github.com/bald6354/tore_volumes).
-
+- [Baldwin et al., Arxiv 2021](#Baldwin21arxiv). Time-Ordered Recent Event (TORE) Volumes for Event Cameras.
 
 <a name="compression"></a>
 ### Compression


### PR DESCRIPTION
I'd like to add our TORE paper to the wiki page. It is an event representation that we tested against 3d human pose estimation using DHP19 dataset. Does it make sense to add a new category for human pose estimation? I think there are at least 3 papers now.

We also tested against intensity image reconstruction, event denoising, and classification. Since this builds on our prior work in denoising I put the main entry there and added links for the other areas.

It is currently published to arxiv. Thanks for maintaining this site. It is incredibly useful!!!