### PR TITLE
Change the calibration paper reference from arXiv 2020 to ACRA 2019

### DIFF
--- a/README.md
+++ b/README.md
@@ -721,9 +721,9 @@ Int. J. Computer Vision (IJCV), 2021.
 - <a name="Wang20arxiv"></a>Wang, Z., Ng, Y., Scheerlinck, C., Mahony., R.,  
 *[An Asynchronous Kalman Filter for Hybrid Event Cameras](https://arxiv.org/abs/2012.05590)*,  
 arXiv, 2020.
-- <a name="Wang20arxivb"></a>Wang, Z., Ng, Y., van Goor, P., Mahony., R.,  
+- <a name="Wang19acra"></a>Wang, Z., Ng, Y., van Goor, P., Mahony., R.,  
 *[Event Camera Calibration of Per-pixel Biased Contrast Threshold](https://arxiv.org/pdf/2012.09378)*,  
-arXiv, 2020.
+Australasian Conference on Robotics and Automation (ACRA) 2019.
 - <a name="GantierCadena21tip"></a>Gantier Cadena, P. R., Qian, Y., Wang, C., Yang, M.,  
 *[SPADE-E2VID: Spatially-Adaptive Denormalization for Event-Based Video Reconstruction](https://doi.org/10.1109/TIP.2021.3052070)*,  
 IEEE Trans. Image Processing, 30:2488-2500, 2021. [Project page](https://github.com/RodrigoGantier/SPADE_E2VID)

--- a/README.md
+++ b/README.md
@@ -723,7 +723,7 @@ Int. J. Computer Vision (IJCV), 2021.
 arXiv, 2020.
 - <a name="Wang19acra"></a>Wang, Z., Ng, Y., van Goor, P., Mahony., R.,  
 *[Event Camera Calibration of Per-pixel Biased Contrast Threshold](https://arxiv.org/pdf/2012.09378)*,  
-Australasian Conference on Robotics and Automation (ACRA) 2019.
+Australasian Conf. Robotics and Automation (ACRA) 2019.
 - <a name="GantierCadena21tip"></a>Gantier Cadena, P. R., Qian, Y., Wang, C., Yang, M.,  
 *[SPADE-E2VID: Spatially-Adaptive Denormalization for Event-Based Video Reconstruction](https://doi.org/10.1109/TIP.2021.3052070)*,  
 IEEE Trans. Image Processing, 30:2488-2500, 2021. [Project page](https://github.com/RodrigoGantier/SPADE_E2VID)


### PR DESCRIPTION
## What is the purpose of the change
The paper "Event Camera Calibration of Per-pixel Biased Contrast Threshold" is accepted in Australasian Conference on Robotics and Automation (ACRA) 2019.
Paper URL in ACRA 2019: https://ssl.linklings.net/conferences/acra/acra2019_program/views/by_date.html
Scopus index url: https://www.scopus.com/inward/record.uri?eid=2-s2.0-85085245994&partnerID=40&md5=fadd0e7e8384e0fa76a3f9c178137f22
## Brief change log
Change paper "Event Camera Calibration of Per-pixel Biased Contrast Threshold" from arXiv 2020 to Australasian Conference on Robotics and Automation (ACRA) 2019.