### PR TITLE
Added the AEStream library under utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -2342,6 +2342,7 @@ Front. Neurosci. (2020), 13:1338. [Code](https://github.com/neuromorphic-paris/t
 - Prophesee automotive dataset toolbox, [Code](https://github.com/prophesee-ai/prophesee-automotive-dataset-toolbox)
 - [dv_ros](https://github.com/kehanXue/dv_ros) ROS package for accumulating event frames with iniVation Dynamic Vision System's dv-sdk.
 - [dvs_event_server](https://github.com/robin-shaun/dvs_event_server) ROS package used to transport "dvs/events" ROS topic to Python through protobuf and zmq, because Python ROS callback has a large delay.
+- [AEStream](https://github.com/norse/aestream/) A fast C++ library with a Python interface for streaming Address Event representations directly from Inivation and Prophesee cameras to various sources, such as STDOUT, UDP (network), or [PyTorch](https://pytorch.org/).
 
 <br><br>
 <a name="processors-platforms"></a>


### PR DESCRIPTION
We recently released a small C++ library for streaming AER data from various sources (`.aedat` files, Inivation cameras, Prophesee cameras, UDP (network)) to various sinks (STDOUT, UDP (network), or PyTorch): https://github.com/norse/aestream/

Hopefully, this is also useful for the community, so I suggest adding it to the list of utilities.