### PR TITLE
Added Brebion et al., SCIA 2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -1041,6 +1041,9 @@ IEEE Robotics and Automation Letters (RA-L), 2021. [PDF](http://rpg.ifi.uzh.ch/d
 - <a name="Muglikar23cvpr"></a>Muglikar, M., Bauersfeld, L., Moeys, D., Scaramuzza, D.,  
 *[Event-based Shape from Polarization](https://arxiv.org/abs/2301.06855)*,  
 IEEE Conf. Computer Vision and Pattern Recognition (CVPR), 2023. [PDF](https://rpg.ifi.uzh.ch/docs/CVPR23_Muglikar.pdf), [YouTube](https://youtu.be/sF3Ue2Zkpec), [code](https://github.com/uzh-rpg/ESfP).  
+- <a name="Brebion23scia"></a>Brebion, V., Moreau, J., Davoine, F.,  
+*[Learning to Estimate Two Dense Depths from LiDAR and Event Data](https://doi.org/10.1007/978-3-031-31438-4_34)*,  
+22nd Scandinavian Conference on Image Analysis (SCIA 2023), 2023. [PDF](https://arxiv.org/pdf/2302.14444.pdf), [Project Page (suppl. mat., poster, code, dataset, videos)](https://vbrebion.github.io/ALED).
 
 <a name="depth-mono-active"></a>
 ### Monocular Depth Estimation using Structured Light


### PR DESCRIPTION
I have added our newly published paper on dense depth estimation to the list.

I have put it under the "Monocular depth estimation" category, which seemed the most fitting, but which is not entirely correct since we fuse events and LiDAR data; do not hesitate to notify me if you want me to move it to another category.